### PR TITLE
refactor: enhance image handling and rendering transparency

### DIFF
--- a/include/Image.h
+++ b/include/Image.h
@@ -70,6 +70,8 @@ class Image {
 
   [[nodiscard]] uint16_t get_height() const { return height_; }
 
+  void set_filename(const std::string& filename) { filename_ = filename; }
+
  private:
   Image(uint16_t w, uint16_t h, std::string filename);
 

--- a/include/experiments/Experiments.h
+++ b/include/experiments/Experiments.h
@@ -70,6 +70,9 @@ inline void run_benchmark(const Renderer::Renderer &renderer,
         absl::StrFormat("Rendered %d shapes in %.2f ms.", n, render_time_ms);
     printf("%s\n", output.c_str());
     absl::StrAppendFormat(&csv_content, "%d,%.6f\n", n, render_time_ms);
+
+    image.set_filename(absl::StrFormat("imgs/output_%d.png", n));
+    const bool _ = image.save();
   }
   const int result = fprintf(output_file, "%s", csv_content.c_str());
   fclose(output_file);

--- a/include/renderer/Renderer.h
+++ b/include/renderer/Renderer.h
@@ -56,18 +56,29 @@ class Renderer {
     const float new_alpha = new_colour.a;
     const float inv_alpha = 1.0f - new_alpha;
 
-    return {new_colour.r * new_alpha + old_colour.r * inv_alpha,
-            new_colour.g * new_alpha + old_colour.g * inv_alpha,
-            new_colour.b * new_alpha + old_colour.b * inv_alpha,
+    return {new_colour.r + old_colour.r * inv_alpha,
+            new_colour.g + old_colour.g * inv_alpha,
+            new_colour.b + old_colour.b * inv_alpha,
             new_alpha + old_colour.a * inv_alpha};
   }
 
   [[nodiscard]] static ColourRGBA8 convert_to_rgba8(
       const Shape::ColourRGBA &float_colour) {
-    return {static_cast<std::uint8_t>(std::lround(float_colour.r * 255.0f)),
-            static_cast<std::uint8_t>(std::lround(float_colour.g * 255.0f)),
-            static_cast<std::uint8_t>(std::lround(float_colour.b * 255.0f)),
-            static_cast<std::uint8_t>(std::lround(float_colour.a * 255.0f))};
+    const auto [r, g, b, a] = unpremultiply(float_colour);
+    return {static_cast<std::uint8_t>(std::lround(r * 255.0f)),
+            static_cast<std::uint8_t>(std::lround(g * 255.0f)),
+            static_cast<std::uint8_t>(std::lround(b * 255.0f)),
+            static_cast<std::uint8_t>(std::lround(a * 255.0f))};
+  }
+
+  [[nodiscard]] static Shape::ColourRGBA unpremultiply(
+      const Shape::ColourRGBA &colour) {
+    if (std::fabs(colour.r) < std::numeric_limits<float>::epsilon()) {
+      return {0.f, 0.f, 0.f, 0.f};
+    }
+    const float inv_alpha = 1.0f / colour.a;
+    return {colour.r * inv_alpha, colour.g * inv_alpha, colour.b * inv_alpha,
+            colour.a};
   }
 
  private:

--- a/include/utils/Utils.h
+++ b/include/utils/Utils.h
@@ -45,7 +45,8 @@ inline void create_shapes(std::vector<std::unique_ptr<Shape::IShape> > &shapes,
   std::uniform_int_distribution<uint16_t> x_distribution(0, width - 1);
   std::uniform_int_distribution<uint16_t> y_distribution(0, height - 1);
   std::uniform_int_distribution<uint8_t> z_distribution(0, 255);
-  std::uniform_real_distribution colour_distribution(0.0f, 1.0f);
+  std::uniform_real_distribution colour_distribution(0.f, 1.0f);
+  std::uniform_real_distribution alpha_distribution(0.f, .9f);
   std::uniform_int_distribution type_distribution(0, 3);
 
   std::uniform_int_distribution<uint16_t> circle_radius_distribution(20, 119);
@@ -55,27 +56,31 @@ inline void create_shapes(std::vector<std::unique_ptr<Shape::IShape> > &shapes,
 
   for (uint16_t i = 0; i < n; ++i) {
     // 75% chance to create a circle
+
+    // Generate a random alpha value for transparency
+    // this ensures that shapes are not fully opaque
+    const float alpha = alpha_distribution(gen);
     if (type_distribution(gen) != 0) {
-      shapes.push_back(
-          Shape::Circle::Builder()
-              .x(x_distribution(gen))
-              .y(y_distribution(gen))
-              .z(z_distribution(gen))
-              .radius(circle_radius_distribution(gen))
-              .colour({colour_distribution(gen), colour_distribution(gen),
-                       colour_distribution(gen), colour_distribution(gen)})
-              .build());
+      shapes.push_back(Shape::Circle::Builder()
+                           .x(x_distribution(gen))
+                           .y(y_distribution(gen))
+                           .z(z_distribution(gen))
+                           .radius(circle_radius_distribution(gen))
+                           .colour({colour_distribution(gen) * alpha,
+                                    colour_distribution(gen) * alpha,
+                                    colour_distribution(gen) * alpha, alpha})
+                           .build());
     } else {
-      shapes.push_back(
-          Shape::Rectangle::Builder()
-              .x(x_distribution(gen))
-              .y(y_distribution(gen))
-              .z(z_distribution(gen))
-              .length(rectangle_length_distribution(gen))
-              .width(rectangle_width_distribution(gen))
-              .colour({colour_distribution(gen), colour_distribution(gen),
-                       colour_distribution(gen), colour_distribution(gen)})
-              .build());
+      shapes.push_back(Shape::Rectangle::Builder()
+                           .x(x_distribution(gen))
+                           .y(y_distribution(gen))
+                           .z(z_distribution(gen))
+                           .length(rectangle_length_distribution(gen))
+                           .width(rectangle_width_distribution(gen))
+                           .colour({colour_distribution(gen) * alpha,
+                                    colour_distribution(gen) * alpha,
+                                    colour_distribution(gen) * alpha, alpha})
+                           .build());
     }
   }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@ int main() {
 
   constexpr int kNumberOfIterations = 10;
 
-  printf("%d", omp_get_max_threads());
+  printf("System's total number of threads: %d\n", omp_get_max_threads());
 
   for (int i = 0; i < kNumberOfIterations; i++) {
     constexpr int kStep = 100;


### PR DESCRIPTION
This pull request introduces improvements to image saving, color blending, and random shape generation, primarily aimed at enhancing rendering accuracy and experiment reproducibility. The most significant changes include better handling of alpha transparency in generated shapes, corrections to color blending logic, and new functionality for saving images with dynamic filenames during benchmarking.

**Rendering and Color Handling Improvements:**

* Updated the alpha blending logic in `Renderer::blend_colours` to correctly handle color composition, and introduced an `unpremultiply` helper to convert premultiplied colors before saving images. This ensures more accurate color representation, especially for transparent shapes. (`include/renderer/Renderer.h`)

**Random Shape Generation Enhancements:**

* Added a separate random distribution for alpha values and changed shape color generation so that shapes are not fully opaque by default. The RGB values are now multiplied by the generated alpha, leading to more realistic transparency effects in rendered shapes. (`include/utils/Utils.h`) [[1]](diffhunk://#diff-e57bb9e1fa6b73a8e7878b5657e1fd585f2da29db7b5573678a771ddeec9697bL48-R49) [[2]](diffhunk://#diff-e57bb9e1fa6b73a8e7878b5657e1fd585f2da29db7b5573678a771ddeec9697bR59-R82)

**Benchmarking and Image Saving:**

* Added functionality to set the output filename for each image generated during benchmarking and save it to disk, allowing for easier tracking and analysis of individual benchmark results. (`include/Image.h`, `include/experiments/Experiments.h`) [[1]](diffhunk://#diff-a02eeff081434c7b33a324c7fe77e6613f893e2df9de4719466b1730df545418R73-R74) [[2]](diffhunk://#diff-6fc5a1ebc81f0894c075fbf1070b74bdba1cc497ebb76c224bc6adf2f1af4529R73-R75)

**Miscellaneous:**

* Improved the startup message in `main.cpp` to clearly state the system's total number of threads, enhancing clarity for users running the program. (`main.cpp`)